### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 savantVersion = "1.0.0"
 
 pubVersion = ""
-project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 savantVersion = "1.0.0"
 
 pubVersion = ""
-project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/fusionauth-ruby-client.iml
+++ b/fusionauth-ruby-client.iml
@@ -9,7 +9,5 @@
     <orderEntry type="jdk" jdkName="rbenv: 2.5.1" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.1.4, rbenv: 2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.8.3, rbenv: 2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rake (v12.3.3, rbenv: 2.5.1) [gem]" level="application" />
   </component>
 </module>

--- a/fusionauth-ruby-client.iml
+++ b/fusionauth-ruby-client.iml
@@ -9,5 +9,7 @@
     <orderEntry type="jdk" jdkName="rbenv: 2.5.1" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.1.4, rbenv: 2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.8.3, rbenv: 2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v12.3.3, rbenv: 2.5.1) [gem]" level="application" />
   </component>
 </module>

--- a/fusionauth_client.gemspec
+++ b/fusionauth_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fusionauth_client'
-  spec.version       = '1.22.0'
+  spec.version       = '1.23.0'
   spec.authors       = ['Brian Pontarelli', 'Daniel DeGroff']
   spec.email         = %w(brian@fusionauth.io daniel@fusionauth.io)
 

--- a/fusionauth_client.gemspec
+++ b/fusionauth_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fusionauth_client'
-  spec.version       = '1.21.1'
+  spec.version       = '1.22.0'
   spec.authors       = ['Brian Pontarelli', 'Daniel DeGroff']
   spec.email         = %w(brian@fusionauth.io daniel@fusionauth.io)
 

--- a/lib/fusionauth/fusionauth_client.rb
+++ b/lib/fusionauth/fusionauth_client.rb
@@ -310,6 +310,20 @@ module FusionAuth
     end
 
     #
+    # Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+    #
+    # @param message_template_id [string] (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+    # @param request [OpenStruct, Hash] The request object that contains all of the information used to create the message template.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def create_message_template(message_template_id, request)
+      start.uri('/api/message/template')
+          .url_segment(message_template_id)
+          .body_handler(FusionAuth::JSONBodyHandler.new(request))
+          .post()
+          .go()
+    end
+
+    #
     # Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
     #
     # @param tenant_id [string] (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -622,6 +636,18 @@ module FusionAuth
     def delete_lambda(lambda_id)
       start.uri('/api/lambda')
           .url_segment(lambda_id)
+          .delete()
+          .go()
+    end
+
+    #
+    # Deletes the message template for the given Id.
+    #
+    # @param message_template_id [string] The Id of the message template to delete.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def delete_message_template(message_template_id)
+      start.uri('/api/message/template')
+          .url_segment(message_template_id)
           .delete()
           .go()
     end
@@ -1290,6 +1316,20 @@ module FusionAuth
     def patch_lambda(lambda_id, request)
       start.uri('/api/lambda')
           .url_segment(lambda_id)
+          .body_handler(FusionAuth::JSONBodyHandler.new(request))
+          .patch()
+          .go()
+    end
+
+    #
+    # Updates, via PATCH, the message template with the given Id.
+    #
+    # @param message_template_id [string] The Id of the message template to update.
+    # @param request [OpenStruct, Hash] The request that contains just the new message template information.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def patch_message_template(message_template_id, request)
+      start.uri('/api/message/template')
+          .url_segment(message_template_id)
           .body_handler(FusionAuth::JSONBodyHandler.new(request))
           .patch()
           .go()
@@ -2008,6 +2048,28 @@ module FusionAuth
           .url_parameter('applicationId', application_id)
           .url_parameter('start', start)
           .url_parameter('end', _end)
+          .get()
+          .go()
+    end
+
+    #
+    # Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+    #
+    # @param message_template_id [string] (Optional) The Id of the message template.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def retrieve_message_template(message_template_id)
+      start.uri('/api/message/template')
+          .url_segment(message_template_id)
+          .get()
+          .go()
+    end
+
+    #
+    # Retrieves all of the message templates.
+    #
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def retrieve_message_templates()
+      start.uri('/api/message/template')
           .get()
           .go()
     end
@@ -2851,6 +2913,20 @@ module FusionAuth
     def update_lambda(lambda_id, request)
       start.uri('/api/lambda')
           .url_segment(lambda_id)
+          .body_handler(FusionAuth::JSONBodyHandler.new(request))
+          .put()
+          .go()
+    end
+
+    #
+    # Updates the message template with the given Id.
+    #
+    # @param message_template_id [string] The Id of the message template to update.
+    # @param request [OpenStruct, Hash] The request that contains all of the new message template information.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def update_message_template(message_template_id, request)
+      start.uri('/api/message/template')
+          .url_segment(message_template_id)
           .body_handler(FusionAuth::JSONBodyHandler.new(request))
           .put()
           .go()

--- a/lib/fusionauth/fusionauth_client.rb
+++ b/lib/fusionauth/fusionauth_client.rb
@@ -2065,6 +2065,18 @@ module FusionAuth
     end
 
     #
+    # Creates a preview of the message template provided in the request, normalized to a given locale.
+    #
+    # @param request [OpenStruct, Hash] The request that contains the email template and optionally a locale to render it in.
+    # @return [FusionAuth::ClientResponse] The ClientResponse object.
+    def retrieve_message_template_preview(request)
+      start.uri('/api/message/template/preview')
+          .body_handler(FusionAuth::JSONBodyHandler.new(request))
+          .post()
+          .go()
+    end
+
+    #
     # Retrieves all of the message templates.
     #
     # @return [FusionAuth::ClientResponse] The ClientResponse object.


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`