### PR TITLE
Patch `reactivate_user` client method

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 
 pubVersion = ""
-project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.43.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-ruby-client", version: "1.43.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/lib/fusionauth/fusionauth_client.rb
+++ b/lib/fusionauth/fusionauth_client.rb
@@ -1992,6 +1992,7 @@ module FusionAuth
       start.uri('/api/user')
           .url_segment(user_id)
           .url_parameter('reactivate', true)
+          .body_handler(FusionAuth::JSONBodyHandler.new(nil))
           .put()
           .go()
     end


### PR DESCRIPTION
This PR addresses https://github.com/FusionAuth/fusionauth-ruby-client/issues/9 by forcing a `Content-Type` of `application/json` in the `PUT` request to reactivate a user. Running locally, this seems to work and make that endpoint happy (i.e., returns 200 and changes are reflected in the UI). I'm not sure why the endpoint necessarily cares about the request's `Content-Type`, but 🤷.